### PR TITLE
log the tensorboard timestamp along with the loss

### DIFF
--- a/run_experiment.py
+++ b/run_experiment.py
@@ -116,8 +116,9 @@ def main(_run):
                 if step <= curr_step:
                     continue
 
+                _run.log_scalar('tb_ts', ts, step)
                 _run.log_scalar('loss', val, step)
-                print('Logged to sacred: step={},loss={}'.format(step, val))
+                print('Logged to sacred: step={},loss={},tb_ts={}'.format(step, val, ts))
                 curr_step = step
 
         if args.no_delete_tpu:


### PR DESCRIPTION
Right now, for the loss metric, the only time recorded in sacred is apparently the time that the loss was logged in run_experiment.py. It seems that in some cases, run_experiment.py re-logs a bunch of prior loss data to sacred, which gives all the prior steps the current time as their timestamps.

This change also logs the original timestamp from tensorboard. This might be useful in measuring the wall-clock time that the run has been taking, in these cases.