### PR TITLE
Noticed typo in flags when trying the training guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ We recommend you use [Huggingface's pretrained GPT2 tokenizer](https://huggingfa
 python data/train_tokenizer.py \
     --base_dir ./path/to/your/txt/files \
     --output_dir ./output/path \
-    --file-type txt \
-    --vocab-size 50257
+    --file_type txt \
+    --vocab_size 50257
 
 # if it succeeded, you should see the message
 # 'tokenizer saved at ./output/path/byte-level-bpe.tokenizer.json'


### PR DESCRIPTION
I was running through the readme to get started on working with this project and noticed that the training instructions have dashes when apparently it was expecting underscores. I figured it's a quick fix to make a PR for, so I did so.