### PR TITLE
Add `import mesh_tensorflow.auto_mtf` for auto layout and mesh-shape

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@ import sys
 import tensorflow.compat.v1 as tf
 import tensorflow.compat.v2 as tf2
 import mesh_tensorflow as mtf
+import mesh_tensorflow.auto_mtf
 from data.encoders import fetch_encoder
 import re
 


### PR DESCRIPTION
```
AttributeError: module 'mtf' has no attribute 'auto_mtf'
```

https://github.com/tensorflow/mesh/issues/247

This error has been reported in the above issue. I don't know the details, but it appears in some versions of mesh-tensorflow. 

- https://github.com/EleutherAI/gpt-neo/blob/master/utils.py#L224
- https://github.com/EleutherAI/gpt-neo/blob/master/utils.py#L229

This problem can be easily solved by adding a single line of code: `import mesh_tensorflow.auto_mtf`. And it also doesn't cause any problems with versions that don't have bugs.