### PR TITLE
Fix trailing token bug in create_tfrecords

### DIFF
--- a/data/create_tfrecords.py
+++ b/data/create_tfrecords.py
@@ -189,13 +189,13 @@ def create_tfrecords(params, write_remainder=True, write_every_n_files=1, save_c
                 continue  # resume from checkpoint
 
             # if the last chunk < chunk size, but > minimum_size, take it and append it to the beginning of the next file
+            data_to_prepend = []
             n_tokens = len(tokenized_files[-1])
             if n_tokens < args.chunk_size:
                 data = tokenized_files.pop(-1)
                 if n_tokens >= args.minimum_size:
                     data_to_prepend = data
                 else:
-                    data_to_prepend = []
                     discarded_files += 1
 
             # add tokenized files > chunk size to main array


### PR DESCRIPTION
Fixes a bug (?) in `create_tfrecords.py`.

----

I noticed that one of my finetuned models would often start in the middle of a sentence when prompted with `"<|endoftext|>"`.  Looking into the issue, I discovered that the training data contained many substrings of this form.

Why?  `create_tfrecords.py` currently does the following:

- When the contents of a document don't exactly divide `n_ctx+1`, the "trailing tokens" at the end of the file are added to an accumulator `data_to_prepend`
- When the accumulator reaches `n_ctx+1` in length, it is added as its own document

The contents of the accumulator end up looking like

```
 the final tokens of file1.<|endoftext|> the final tokens of file2.<|endoftext|> the final tokens of file3.<|endoftext|> [...]
```

Everything after the first separator is not a valid subsequence of the full tokenized dataset.

----

This PR changes the behavior to the one I had expected originally.